### PR TITLE
add on_curve?/1

### DIFF
--- a/lib/ed25519.ex
+++ b/lib/ed25519.ex
@@ -119,6 +119,19 @@ defmodule Ed25519 do
   defp isoncurve({x, y}), do: (-x * x + y * y - 1 - @d * x * x * y * y) |> mod(@p) == 0
 
   @doc """
+  Returns whether a given `key` lies on the ed25519 curve.
+  """
+  @spec on_curve?(key) :: boolean
+  def on_curve?(key) do
+    try do
+      decodepoint(key)
+      true
+    rescue
+      _error -> false
+    end
+  end
+
+  @doc """
   Sign a message
 
   If only the secret key is provided, the public key will be derived therefrom.


### PR DESCRIPTION
Hi there,

I need to check if a derived hash is on the ed25519 curve for a project
I'm building. It looks like the functionality to check this is already
available in this library, but not publicly. So I added `on_curve?/1` to
expose it.

I wrote it like this because of how the rest of the code is structured,
but if the `try`/`rescue` is too messy I can refactor `decodepoint/1` to
return an error tuple instead of raising an error.

Let me know if you'd like me to refactor this function in any way or add
any tests. Thanks!
